### PR TITLE
新規・編集に応じて社員番号の初期値変更

### DIFF
--- a/app/views/shared/_new-input-form.html.erb
+++ b/app/views/shared/_new-input-form.html.erb
@@ -8,7 +8,11 @@
         社員番号
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_field :employee_number, class:"input-default", id:"employee_number", placeholder:"例) 1234", maxlength:"20"  %>
+  <% if @item.new_record? %><%#新規登録の時はカレントユーザの社員番号を初期値として設定%>
+    <%= f.text_field :employee_number, value: current_user.employee_number , class:"input-default", id:"employee_number", placeholder:"例) 1234", maxlength:"20"  %>
+  <% else %> <%#編集の時は登録されているユーザの社員番号を初期値として設定%>
+    <%= f.text_field :employee_number, value: @item.user.employee_number , class:"input-default", id:"employee_number", placeholder:"例) 1234", maxlength:"20"  %>
+  <% end %>
     </div>
 
 


### PR DESCRIPTION
# What
編集時に初期値が空欄にならない、新規の際は初期値をログインしているユーザの社員番号に設定
入力の手間を削減するため

# Why
新規機器登録・編集に応じて社員番号の初期値変更