### PR TITLE
機器情報編集時のエラー解消

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,6 +28,7 @@ class ItemsController < ApplicationController
 
   
   def edit
+    @employee_number = @item.user.employee_number
     unless @item.user_id == current_user.id || current_user&.admin?
       redirect_to root_path
     end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,7 @@
 <%= render "shared/second-header" %>
 
 <%= form_with model: @user, url: user_session_path, class: 'registration-main', local: true do |f| %>
+  <%= render "devise/shared/error_messages" %>
   <div class='form-wrap'>
   <h2 class="login-user-title">ログイン画面</h2>
     <div class="form-group">

--- a/app/views/shared/_new-input-form.html.erb
+++ b/app/views/shared/_new-input-form.html.erb
@@ -11,7 +11,7 @@
       <% if @item.new_record? %><%#新規登録の時はカレントユーザの社員番号を初期値として設定%>
         <%= f.text_field :employee_number, value: current_user.employee_number , class:"items-text", id:"employee-number", placeholder:"例) 1234", maxlength:"20"  %>
       <% else %> <%#編集の時は登録されているユーザの社員番号を初期値として設定%>
-        <%= f.text_field :employee_number, value: @item.user.employee_number , class:"items-text", id:"employee-number", placeholder:"例) 1234", maxlength:"20"  %>
+        <%= f.text_field :employee_number, value: @employee_number , class:"items-text", id:"employee-number", placeholder:"例) 1234", maxlength:"20"  %>
       <% end %>
       <span id="employee-number-error" class="error-message"></span>
     </div>


### PR DESCRIPTION
# What
機器情報編集時のエラー解消
編集画面へリダイレクトされた際は社員番号の初期値は空欄へ

# Why
機器情報編集時に、登録のない社員番号入力して登録ボタンを押すとエラーとなっていたため
正しくは、編集画面にリダイレクトされる必要がある。